### PR TITLE
rename instances of legacy Switch_Keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Features:
 
 - web interface available at [keyboard-tools.xyz](http://keyboard-tools.xyz)
 - two switch libraries to choose from: [MX_Alps_Hybrid](https://github.com/ai03-2725/MX_Alps_Hybrid)
-  and [Switch_Keyboard](https://github.com/perigoso/keyswitch-kicad-library)
+  and [keyswitch-kicad-library](https://github.com/perigoso/keyswitch-kicad-library)
 - three available switch footprints: Cherry MX, Alps and Cherry MX/Alps hybrid
 - key rotations thanks to patched [kle-serial](https://github.com/ijprest/kle-serial)
 - supports basic pre-routing
@@ -89,7 +89,7 @@ Access the application on http://localhost
 - keyboard layout file serialized by [kle-serial](https://github.com/ijprest/kle-serial)
 - netlist generated with [skidl](https://github.com/xesscorp/skidl) based [kle2netlist](https://github.com/adamws/kle2netlist)
 - switch footprints by [MX_Alps_Hybrid](https://github.com/ai03-2725/MX_Alps_Hybrid)
-  and [Switch_Keyboard](https://github.com/perigoso/Switch_Keyboard)
+  and [keyswitch-kicad-library](https://github.com/perigoso/keyswitch-kicad-library)
 - key placement with [kicad-kbplacer](https://github.com/adamws/kicad-kbplacer)
 - pcb preview generated with [pcbdraw](https://github.com/yaqwsx/PcbDraw)
 - project structure generated with [goxygen](https://github.com/Shpota/goxygen)

--- a/docs/src/kicad-project-generator/features.md
+++ b/docs/src/kicad-project-generator/features.md
@@ -23,7 +23,7 @@ Which produces this layout:
 
 ## Footprint library
 
-User can choose between two footprint libraries: [perigoso/Switch_Keyboard](https://github.com/perigoso/keyswitch-kicad-library)
+User can choose between two footprint libraries: [perigoso/keyswitch-kicad-library](https://github.com/perigoso/keyswitch-kicad-library)
 and [ai03-2725/MX_Alps_Hybrid](https://github.com/ai03-2725/MX_Alps_Hybrid).
 MX_Alps_Hybrid has become de facto standard in mechanical keyboard maker
 community but alternative by perigoso (which is based on ai03-2725 work)

--- a/kicad-api/src/tasks.py
+++ b/kicad-api/src/tasks.py
@@ -46,17 +46,17 @@ def __prepare_project(project_full_path, project_name, switch_library):
     tm = Template(
         "(fp_lib_table\n{% for fp_lib in fp_libs -%}{{ fp_lib }}\n{% endfor %})"
     )
-    if switch_library == "perigoso/Switch_Keyboard":
+    if switch_library == "perigoso/keyswitch-kicad-library":
         fp_lib_table = tm.render(
             fp_libs=[
-                '(lib (name Switch_Keyboard_Cherry_MX)(type KiCad)(uri ${KIPRJMOD}/libs/Switch_Keyboard/modules/Switch_Keyboard_Cherry_MX.pretty)(options "")(descr ""))',
-                '(lib (name Switch_Keyboard_Alps_Matias)(type KiCad)(uri ${KIPRJMOD}/libs/Switch_Keyboard/modules/Switch_Keyboard_Alps_Matias.pretty)(options "")(descr ""))',
-                '(lib (name Switch_Keyboard_Hybrid)(type KiCad)(uri ${KIPRJMOD}/libs/Switch_Keyboard/modules/Switch_Keyboard_Hybrid.pretty)(options "")(descr ""))',
-                '(lib (name Mounting_Keyboard_Stabilizer)(type KiCad)(uri ${KIPRJMOD}/libs/Switch_Keyboard/modules/Mounting_Keyboard_Stabilizer.pretty)(options "")(descr ""))',
+                '(lib (name Switch_Keyboard_Cherry_MX)(type KiCad)(uri ${KIPRJMOD}/libs/keyswitch-kicad-library/modules/Switch_Keyboard_Cherry_MX.pretty)(options "")(descr ""))',
+                '(lib (name Switch_Keyboard_Alps_Matias)(type KiCad)(uri ${KIPRJMOD}/libs/keyswitch-kicad-library/modules/Switch_Keyboard_Alps_Matias.pretty)(options "")(descr ""))',
+                '(lib (name Switch_Keyboard_Hybrid)(type KiCad)(uri ${KIPRJMOD}/libs/keyswitch-kicad-library/modules/Switch_Keyboard_Hybrid.pretty)(options "")(descr ""))',
+                '(lib (name Mounting_Keyboard_Stabilizer)(type KiCad)(uri ${KIPRJMOD}/libs/keyswitch-kicad-library/modules/Mounting_Keyboard_Stabilizer.pretty)(options "")(descr ""))',
             ]
         )
         shutil.copytree(
-            "switch-libs/Switch_Keyboard", f"{project_full_path}/libs/Switch_Keyboard"
+            "switch-libs/keyswitch-kicad-library", f"{project_full_path}/libs/keyswitch-kicad-library"
         )
     else:
         fp_lib_table = tm.render(

--- a/kicad-api/worker.Dockerfile
+++ b/kicad-api/worker.Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir switch-libs \
   && rm -rf $AI03_LIB-master.zip \
   && curl -LJO https://github.com/perigoso/$PERIGOSO_LIB/archive/main.zip \
   && unzip $PERIGOSO_LIB-main.zip \
-  && mv $PERIGOSO_LIB-main switch-libs/Switch_Keyboard \
+  && mv $PERIGOSO_LIB-main switch-libs/keyswitch-kicad-library \
   && rm -rf $PERIGOSO_LIB-main.zip
 
 ENV KICAD_SYMBOL_DIR=/usr/share/kicad/library

--- a/webapp/src/components/PcbSettings.vue
+++ b/webapp/src/components/PcbSettings.vue
@@ -39,12 +39,12 @@ export default {
   data() {
     return {
       matrixOptions: ["Automatic", "Predefined"],
-      switchLibraryOptions: ["perigoso/Switch_Keyboard", "ai03-2725/MX_Alps_Hybrid"],
+      switchLibraryOptions: ["perigoso/keyswitch-kicad-library", "ai03-2725/MX_Alps_Hybrid"],
       switchFootprintOptions: ["MX", "Alps", "MX/Alps Hybrid"],
       routingOptions: ["Disabled", "Full"],
 
       matrixOption: "Automatic",
-      switchLibrary: "perigoso/Switch_Keyboard",
+      switchLibrary: "perigoso/keyswitch-kicad-library",
       switchFootprint: "MX",
       routingOption: "Disabled",
     }


### PR DESCRIPTION
The library name was changed recently, so some links and references were outdated.

Ihis is untested, i don't think i broke anything though.